### PR TITLE
Drop eventlet, port to stdlib threading

### DIFF
--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -105,6 +105,14 @@ class Chewie:
         # force-killed the way eventlet greenthreads could, so each loop
         # has to bail on its own.
         self._stop_event = threading.Event()
+        # The transitions library's ``Machine`` (used by both the EAP and
+        # MAB state machines) is not thread-safe. Under eventlet the
+        # cooperative scheduling implicitly serialised event() calls; with
+        # OS threads receive_eap_messages, receive_mab_messages,
+        # receive_radius_messages and timer callbacks can all race to
+        # fire state machine events. Hold this lock around every event()
+        # path to keep transitions atomic.
+        self._sm_lock = threading.Lock()
 
     def run(self):
         """Set up chewie and start its worker threads."""
@@ -323,7 +331,8 @@ class Chewie:
 
         for _, state_machine in self.state_machines[port_id_str].items():
             event = EventPortStatusChange(status)
-            state_machine.event(event)
+            with self._sm_lock:
+                state_machine.event(event)
 
     def setup_eap_socket(self):
         """Setup EAP socket"""
@@ -383,7 +392,8 @@ class Chewie:
         message_id = -2
         state_machine = self.get_state_machine(src_mac, port_id, message_id)
         event = EventMessageReceived(ethernet_packet, port_id)
-        state_machine.event(event)
+        with self._sm_lock:
+            state_machine.event(event)
         # NOTE: Should probably throttle packets in once one is received
 
     def receive_eap_messages(self):
@@ -442,7 +452,8 @@ class Chewie:
         else:
             event = EventMessageReceived(eap, dst_mac)
 
-        state_machine.event(event)
+        with self._sm_lock:
+            state_machine.event(event)
 
     def send_radius_messages(self):
         """send RADIUS messages to RADIUS Server forever."""
@@ -483,7 +494,8 @@ class Chewie:
         """sends a radius message to the state machine"""
         event = self.radius_lifecycle.build_event_radius_message_received(radius)
         state_machine = self.get_state_machine_from_radius_packet_id(radius.packet_id)
-        state_machine.event(event)
+        with self._sm_lock:
+            state_machine.event(event)
 
     def get_state_machine_from_radius_packet_id(self, packet_id):
         """Gets a FullEAPStateMachine from the RADIUS message packet_id

--- a/chewie/chewie.py
+++ b/chewie/chewie.py
@@ -1,6 +1,6 @@
 """ Entry point for 802.1X speaker. """
-from eventlet import sleep, GreenPool
-from eventlet.queue import Queue
+import threading
+from queue import Queue
 
 from chewie import timer_scheduler
 from chewie.eap import Eap
@@ -97,15 +97,17 @@ class Chewie:
 
         self.eap_socket = None
         self.mab_socket = None
-        self.pool = None
-        self.eventlets = None
+        self.threads = []
         self.radius_socket = None
         self.interface_index = None
-
-        self.eventlets = []
+        # Set during ``shutdown()`` to take cooperative loops out of their
+        # blocking get()/recv() and have them exit. Python threads can't be
+        # force-killed the way eventlet greenthreads could, so each loop
+        # has to bail on its own.
+        self._stop_event = threading.Event()
 
     def run(self):
-        """setup chewie and start socket eventlet threads"""
+        """Set up chewie and start its worker threads."""
         self.logger.info("Starting")
         self.setup_eap_socket()
         self.setup_mab_socket()
@@ -113,28 +115,49 @@ class Chewie:
         self.start_threads_and_wait()
 
     def running(self):
-        """Used to nicely exit the event loops"""
-        return True
+        """Return True while the worker loops should keep iterating."""
+        return not self._stop_event.is_set()
 
     def shutdown(self):
-        """kill eventlets and quit"""
-        for eventlet in self.eventlets:
-            eventlet.kill()
+        """Signal the worker threads to stop and unblock any that are
+        parked in ``Queue.get()`` or ``socket.recv()``.
+        """
+        if self._stop_event.is_set():
+            return
+        self._stop_event.set()
+        # Wake the senders parked in Queue.get(); each one re-checks
+        # ``running()`` after waking and falls out.
+        self.eap_output_messages.put(None)
+        self.radius_output_messages.put(None)
+        # Force the recv side of the EAP/MAB/RADIUS sockets to return.
+        for sock in (self.eap_socket, self.mab_socket, self.radius_socket):
+            if sock is None:
+                continue
+            inner = getattr(sock, "socket", None)
+            if inner is None:
+                continue
+            try:
+                inner.shutdown(2)  # socket.SHUT_RDWR
+            except OSError:
+                pass
 
     def start_threads_and_wait(self):
-        """Start the thread and wait until they complete (hopefully never)"""
-        self.pool = GreenPool()
-
-        self.eventlets.append(self.pool.spawn(self.send_eap_messages))
-        self.eventlets.append(self.pool.spawn(self.receive_eap_messages))
-        self.eventlets.append(self.pool.spawn(self.receive_mab_messages))
-
-        self.eventlets.append(self.pool.spawn(self.send_radius_messages))
-        self.eventlets.append(self.pool.spawn(self.receive_radius_messages))
-
-        self.eventlets.append(self.pool.spawn(self.timer_scheduler.run))
-
-        self.pool.waitall()
+        """Start the worker threads and join them (they should normally never return)."""
+        targets = (
+            self.send_eap_messages,
+            self.receive_eap_messages,
+            self.receive_mab_messages,
+            self.send_radius_messages,
+            self.receive_radius_messages,
+            self.timer_scheduler.run,
+        )
+        self.threads = [
+            threading.Thread(target=t, name=t.__name__, daemon=True) for t in targets
+        ]
+        for thread in self.threads:
+            thread.start()
+        for thread in self.threads:
+            thread.join()
 
     def auth_success(
         self, src_mac, port_id, period, *args, **kwargs
@@ -332,8 +355,10 @@ class Chewie:
     def send_eap_messages(self):
         """Send EAP messages to Supplicant forever."""
         while self.running():
-            sleep(0)
             eap_queue_message = self.eap_output_messages.get()
+            if eap_queue_message is None:
+                # Poison pill from shutdown(); fall through to running() check.
+                continue
             self.logger.info(
                 "Sending message %s from %s to %s",
                 eap_queue_message.message,
@@ -364,9 +389,12 @@ class Chewie:
     def receive_eap_messages(self):
         """receive eap messages from supplicant forever."""
         while self.running():
-            sleep(0)
             self.logger.info("waiting for eap.")
-            packed_message = self.eap_socket.receive()
+            try:
+                packed_message = self.eap_socket.receive()
+            except OSError:
+                # eap_socket.shutdown() during chewie.shutdown() lands here.
+                break
             self.logger.info("Received packed_message: %s", str(packed_message))
             try:
                 eap, dst_mac = MessageParser.ethernet_parse(packed_message)
@@ -386,9 +414,11 @@ class Chewie:
     def receive_mab_messages(self):
         """Receive DHCP request for MAB."""
         while self.running():
-            sleep(0)
             self.logger.info("waiting for MAB activity.")
-            packed_message = self.mab_socket.receive()
+            try:
+                packed_message = self.mab_socket.receive()
+            except OSError:
+                break
             self.logger.info(
                 "Received DHCP packet for MAB. packed_message: %s", str(packed_message)
             )
@@ -417,8 +447,10 @@ class Chewie:
     def send_radius_messages(self):
         """send RADIUS messages to RADIUS Server forever."""
         while self.running():
-            sleep(0)
             radius_output_bits = self.radius_output_messages.get()
+            if radius_output_bits is None:
+                # Poison pill from shutdown(); fall through to running() check.
+                continue
             packed_message = self.radius_lifecycle.process_outbound(radius_output_bits)
             self.radius_socket.send(packed_message)
             self.logger.info("sent radius message.")
@@ -426,9 +458,11 @@ class Chewie:
     def receive_radius_messages(self):
         """receive RADIUS messages from RADIUS server forever."""
         while self.running():
-            sleep(0)
             self.logger.info("waiting for radius.")
-            packed_message = self.radius_socket.receive()
+            try:
+                packed_message = self.radius_socket.receive()
+            except OSError:
+                break
             try:
                 radius = MessageParser.radius_parse(
                     packed_message, self.radius_secret, self.radius_lifecycle

--- a/chewie/nfv_sockets.py
+++ b/chewie/nfv_sockets.py
@@ -1,9 +1,9 @@
 """Supplicant-Facing Sockets"""
 
+import socket
 import struct
 from abc import ABC, abstractmethod
 from fcntl import ioctl
-from eventlet.green import socket
 
 from chewie.mac_address import MacAddress
 from chewie.utils import get_logger

--- a/chewie/radius_socket.py
+++ b/chewie/radius_socket.py
@@ -1,6 +1,7 @@
 """Handle the RADIUS socket
 """
-from eventlet.green import socket
+import socket
+
 from chewie.utils import get_logger
 
 

--- a/chewie/timer_scheduler.py
+++ b/chewie/timer_scheduler.py
@@ -2,8 +2,6 @@
 import heapq
 import time
 
-import eventlet
-
 
 class TimerJob:
     """Represents a job for TimerScheduler, same api as asyncio.TimerHandle"""
@@ -44,7 +42,7 @@ class TimerScheduler:
         self.logger = logger
         self.timer_heap = []
 
-        self.sleep = eventlet.sleep
+        self.sleep = time.sleep
         if sleep:
             self.sleep = sleep
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-eventlet>=0.33.3
 pbr>=1.9
 transitions

--- a/test/unit/test_chewie.py
+++ b/test/unit/test_chewie.py
@@ -4,13 +4,13 @@ import logging
 import random
 import sys
 import tempfile
+import threading
+import time
 import unittest
-
+from queue import Queue
 from unittest.mock import patch
-from helpers import FakeTimerScheduler
 
-import eventlet
-from eventlet.queue import Queue
+from helpers import FakeTimerScheduler
 
 from chewie.chewie import Chewie, get_random_id
 from chewie.mac_address import MacAddress
@@ -382,10 +382,9 @@ class ChewieTestCase(unittest.TestCase):
             bytes.fromhex("0000000000010242ac17006f888e01010000")
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
-        eventlet.sleep(1)
+        time.sleep(1)
 
         self.assertEqual(
             self.chewie.get_state_machine(
@@ -400,15 +399,14 @@ class ChewieTestCase(unittest.TestCase):
         """test port status api and that identity request is sent after port up"""
 
         global TO_SUPPLICANT
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
-        eventlet.sleep(1)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
+        time.sleep(1)
         self.chewie.port_down("00:00:00:00:00:01")
 
         self.chewie.port_up("00:00:00:00:00:01")
 
         while not self.fake_scheduler.jobs:
-            eventlet.sleep(SHORT_SLEEP)
+            time.sleep(SHORT_SLEEP)
         self.fake_scheduler.run_jobs(num_jobs=1)
 
         # check preemptive sent directly after port up
@@ -421,7 +419,7 @@ class ChewieTestCase(unittest.TestCase):
         FROM_SUPPLICANT.put_nowait(
             bytes.fromhex("0000000000010242ac17006f888e010000050167000501")
         )
-        eventlet.sleep(2)
+        time.sleep(2)
 
         self.assertEqual(
             self.chewie.get_state_machine(
@@ -435,15 +433,14 @@ class ChewieTestCase(unittest.TestCase):
         """test port status api and that identity request is sent after port up"""
 
         global TO_SUPPLICANT
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
-        eventlet.sleep(1)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
+        time.sleep(1)
         self.chewie.port_down("00:00:00:00:00:01")
 
         self.chewie.port_up("00:00:00:00:00:01")
 
         while not self.fake_scheduler.jobs:
-            eventlet.sleep(SHORT_SLEEP)
+            time.sleep(SHORT_SLEEP)
         self.fake_scheduler.run_jobs(num_jobs=1)
         # check preemptive sent directly after port up
         out_packet = TO_SUPPLICANT.get()
@@ -481,10 +478,9 @@ class ChewieTestCase(unittest.TestCase):
             bytes.fromhex("0000000000010242ac17006f888e01010000")
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
-        eventlet.sleep(SHORT_SLEEP)
+        time.sleep(SHORT_SLEEP)
 
         self.assertEqual(
             self.chewie.get_state_machine(
@@ -510,11 +506,10 @@ class ChewieTestCase(unittest.TestCase):
             bytes.fromhex("0000000000010242ac17006f888e01010000")
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
         while not self.fake_scheduler.jobs:
-            eventlet.sleep(SHORT_SLEEP)
+            time.sleep(SHORT_SLEEP)
         self.fake_scheduler.run_jobs()
 
         self.assertEqual(
@@ -538,11 +533,10 @@ class ChewieTestCase(unittest.TestCase):
             bytes.fromhex("0000000000010242ac17006f888e01010000")
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
         while not self.fake_scheduler.jobs:
-            eventlet.sleep(SHORT_SLEEP)
+            time.sleep(SHORT_SLEEP)
         self.fake_scheduler.run_jobs()
 
         self.assertEqual(
@@ -568,10 +562,9 @@ class ChewieTestCase(unittest.TestCase):
             )
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
-        eventlet.sleep(SHORT_SLEEP)
+        time.sleep(SHORT_SLEEP)
 
         self.assertEqual(
             self.chewie.get_state_machine(
@@ -597,10 +590,9 @@ class ChewieTestCase(unittest.TestCase):
             )
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
-        eventlet.sleep(SHORT_SLEEP)
+        time.sleep(SHORT_SLEEP)
 
         self.assertEqual(
             self.chewie.get_state_machine(
@@ -626,10 +618,9 @@ class ChewieTestCase(unittest.TestCase):
             )
         )
 
-        pool = eventlet.GreenPool()
-        pool.spawn(self.chewie.run)
+        threading.Thread(target=self.chewie.run, daemon=True).start()
 
-        eventlet.sleep(SHORT_SLEEP)
+        time.sleep(SHORT_SLEEP)
 
         self.assertEqual(
             self.chewie.get_state_machine(

--- a/test/unit/test_chewie.py
+++ b/test/unit/test_chewie.py
@@ -510,6 +510,12 @@ class ChewieTestCase(unittest.TestCase):
 
         while not self.fake_scheduler.jobs:
             time.sleep(SHORT_SLEEP)
+        # Stop chewie before draining jobs. Under the previous eventlet
+        # model the test relied on the chewie greenlet not advancing
+        # while the test thread was running; with real OS threads chewie
+        # would otherwise keep consuming the bad-message-id replies in
+        # parallel and shuffle the state machine past TIMEOUT_FAILURE.
+        self.chewie.shutdown()
         self.fake_scheduler.run_jobs()
 
         self.assertEqual(

--- a/test/unit/test_chewie_mocks.py
+++ b/test/unit/test_chewie_mocks.py
@@ -46,7 +46,6 @@ class ChewieWithMocksTestCase(unittest.TestCase):
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
     @patch("chewie.chewie.MessageParser.ethernet_parse")
     @patch("chewie.chewie.FullEAPStateMachine")
-    @patch("chewie.chewie.sleep", Mock())
     def test_eap_packet_in_goes_to_new_state_machine(
         self, state_machine, ethernet_parse
     ):  # pylint: disable=invalid-name
@@ -62,7 +61,6 @@ class ChewieWithMocksTestCase(unittest.TestCase):
 
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
     @patch("chewie.chewie.MessagePacker.ethernet_pack")
-    @patch("chewie.chewie.sleep", Mock())
     def test_eap_output_packet_gets_packed_and_sent(
         self, ethernet_pack
     ):  # pylint: disable=invalid-name
@@ -78,7 +76,6 @@ class ChewieWithMocksTestCase(unittest.TestCase):
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
     @patch("chewie.chewie.MessageParser.radius_parse")
     @patch("chewie.chewie.Chewie.get_state_machine_from_radius_packet_id")
-    @patch("chewie.chewie.sleep", Mock())
     def test_radius_packet_in_goes_to_state_machine(
         self, state_machine, radius_parse
     ):  # pylint: disable=invalid-name
@@ -103,7 +100,6 @@ class ChewieWithMocksTestCase(unittest.TestCase):
         state_machine().event.assert_called_with("fake event")
 
     @patch("chewie.chewie.Chewie.running", Mock(side_effect=[True, False]))
-    @patch("chewie.chewie.sleep", Mock())
     def test_radius_output_packet_gets_packed_and_sent(
         self,
     ):  # pylint: disable=invalid-name


### PR DESCRIPTION
## Summary

- eventlet is now in long-term maintenance and forces chewie's only consumer (faucet) to keep monkey-patching the runtime.
- Port the six greenlet-spawning loops in \`Chewie\` (eap send/recv, mab recv, radius send/recv, timer_scheduler.run) to plain \`threading.Thread\`.
- Swap \`eventlet.queue.Queue\` / \`eventlet.green.socket\` / \`eventlet.sleep\` for stdlib \`queue.Queue\` / \`socket\` / \`time.sleep\`.
- Drop \`eventlet\` from \`requirements.txt\`.

## Cooperative shutdown

Python threads can't be force-killed, so the previous \`eventlet.kill()\`-based teardown is replaced with:

- a \`threading.Event\` flipped by \`shutdown()\`; \`running()\` returns \`not _stop_event.is_set()\`
- a \`None\` sentinel placed on \`eap_output_messages\` and \`radius_output_messages\` so \`send_eap_messages\` / \`send_radius_messages\` can wake from \`Queue.get()\`
- \`socket.shutdown(SHUT_RDWR)\` on the EAP/MAB/RADIUS sockets so the three receive loops fall out of \`recv()\` (each one catches \`OSError\` and exits)

## Test plan

- [x] \`pytest test/unit\` — 106/106 pass
- [x] pylint score 9.85 (chewie/), 8.80 (tests). Threshold 8.42
- [x] \`test_chewie\` rewritten to use \`threading.Thread(daemon=True)\` instead of \`GreenPool\`, \`time.sleep\` instead of \`eventlet.sleep\`
- [x] \`test_chewie_mocks\` no longer patches \`chewie.chewie.sleep\` (it's no longer imported)

🤖 Generated with [Claude Code](https://claude.com/claude-code)