### PR TITLE
Migrate PyPI publishing to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: "release"
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v6
@@ -24,7 +27,4 @@ jobs:
       - name: Build python package
         run: python3 setup.py sdist
       - name: Publish python package to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Migrates PyPI publishing to **Trusted Publishing** (OIDC) so the stored API token can be removed.

## What changed
- Added `id-token: write` to the publish job.
- Removed the `PYPI_TOKEN` password from `pypa/gh-action-pypi-publish` (now authenticates via OIDC) and pinned the action to `@release/v1`.

## ⚠️ Required before the next release (PyPI side)
Add a GitHub Actions Trusted Publisher at https://pypi.org/manage/project/chewie/settings/publishing/ :
| Field | Value |
|---|---|
| Owner | `c65sdn` |
| Repository | `chewie` |
| Workflow name | `release-python.yml` |
| Environment | `release` |

Merging this PR does **not** trigger a publish (release runs on tags only), so configure PyPI first, then tag a release to verify.

## After a verified OIDC release
- Delete the `PYPI_TOKEN` secret (environment `release`) from this repo.
- Revoke that token on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
